### PR TITLE
[13.0] shopinvader_payment: ugly patch to make payment not fail

### DIFF
--- a/shopinvader_payment/components/payment_transaction_event_listerner.py
+++ b/shopinvader_payment/components/payment_transaction_event_listerner.py
@@ -32,6 +32,11 @@ class SaleOrderPaymentTransactionEventListener(Component):
             # another ugly hack: the partner here should be taken
             # from current client request
             setattr(work, "partner", sale_order.partner_id)
+
+            invader_partner = sale_order.partner_id._get_invader_partner(shopinvader_backend)
+            setattr(work, "invader_partner", invader_partner)
+            setattr(work, "invader_partner_user", invader_partner)
+
             res = work.component(usage="cart")._to_json(sale_order)
             response.set_store_cache("last_sale", res.get("data", {}))
             # end of awful code ....


### PR DESCRIPTION
Ugly hack to make me survive by the weekend :sweat_smile: 

Recently I've introduced few more vars in the ctx to be able to rely on the real invader partner https://github.com/shopinvader/odoo-shopinvader/blob/13.0/shopinvader/controllers/main.py#L101

BUT the service here is not using the same ctx. We should get back to the comment on line 22 and refactor this thing once for all as it's not reliable.

TBD.