### PR TITLE
[12.0][FIX] test_invader_payment: Direct call of the method on the abract c…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     args: [--extend-ignore=F401]  # ignore imported unused in __init__.py
     files: __init__.py
 - repo: https://github.com/pre-commit/mirrors-pylint
-  rev: v2.3.1
+  rev: v2.3.0
   hooks:
     - id: pylint
       args: ["--rcfile=.pylintrc"]

--- a/test_invader_payment/tests/common.py
+++ b/test_invader_payment/tests/common.py
@@ -4,11 +4,11 @@
 
 from odoo.addons.base_rest.controllers.main import _PseudoCollection
 from odoo.addons.component.core import WorkContext
-from odoo.addons.component.tests.common import TransactionComponentCase
+from odoo.addons.component.tests.common import SavepointComponentCase
 from odoo.addons.shopinvader import shopinvader_response
 
 
-class TestCommonPayment(TransactionComponentCase):
+class TestCommonPayment(SavepointComponentCase):
     def setUp(self):
         super(TestCommonPayment, self).setUp()
         shopinvader_response.set_testmode(True)

--- a/test_invader_payment/tests/test_invader_payment_manual.py
+++ b/test_invader_payment/tests/test_invader_payment_manual.py
@@ -20,12 +20,8 @@ class TestInvaderPaymentManual(TestCommonPayment):
         existing_transactions = self.env["payment.transaction"].search(
             [("acquirer_id", "=", self.payment_mode.payment_acquirer_id.id)]
         )
-        self.service.dispatch(
-            "add_payment",
-            params={
-                "target": "demo_partner",
-                "payment_mode_id": self.payment_mode.id,
-            },
+        self.service.add_payment(
+            target="demo_partner", payment_mode_id=self.payment_mode.id
         )
         transaction = self.env["payment.transaction"].search(
             [
@@ -41,12 +37,9 @@ class TestInvaderPaymentManual(TestCommonPayment):
             "invader_payment_stripe.payment_mode_stripe"
         )
         with self.assertRaises(UserError) as m:
-            self.service.dispatch(
-                "add_payment",
-                params={
-                    "target": "demo_partner",
-                    "payment_mode_id": self.payment_mode_stripe.id,
-                },
+            self.service.add_payment(
+                target="demo_partner",
+                payment_mode_id=self.payment_mode_stripe.id,
             )
         self.assertEqual(
             m.exception.name,

--- a/test_invader_payment/tests/test_invader_payment_sips.py
+++ b/test_invader_payment/tests/test_invader_payment_sips.py
@@ -47,14 +47,11 @@ class TestInvaderPaymentSips(VCRMixin, TestCommonPayment):
         }
 
     def test_prepare_payment(self):
-        result = self.service.dispatch(
-            "prepare_payment",
-            params={
-                "target": "demo_partner",
-                "payment_mode_id": self.payment_mode.id,
-                "normal_return_url": NORMAL_RETURN_URL,
-                "automatic_response_url": AUTOMATIC_RESPONSE_URL,
-            },
+        result = self.service.prepare_payment(
+            target="demo_partner",
+            payment_mode_id=self.payment_mode.id,
+            normal_return_url=NORMAL_RETURN_URL,
+            automatic_response_url=AUTOMATIC_RESPONSE_URL,
         )
         response = requests.post(
             result["sips_form_action_url"],
@@ -71,14 +68,11 @@ class TestInvaderPaymentSips(VCRMixin, TestCommonPayment):
             "invader_payment_manual.payment_mode_check"
         )
         with self.assertRaises(UserError) as m:
-            self.service.dispatch(
-                "prepare_payment",
-                params={
-                    "target": "demo_partner",
-                    "payment_mode_id": self.payment_mode_check.id,
-                    "normal_return_url": NORMAL_RETURN_URL,
-                    "automatic_response_url": AUTOMATIC_RESPONSE_URL,
-                },
+            self.service.prepare_payment(
+                target="demo_partner",
+                payment_mode_id=self.payment_mode_check.id,
+                normal_return_url=NORMAL_RETURN_URL,
+                automatic_response_url=AUTOMATIC_RESPONSE_URL,
             )
         self.assertEqual(
             m.exception.name,

--- a/test_invader_payment/tests/test_invader_payment_stripe.py
+++ b/test_invader_payment/tests/test_invader_payment_stripe.py
@@ -42,13 +42,10 @@ class TestInvaderPaymentStripe(VCRMixin, TestCommonPayment):
         next_response["body"]["string"] = json.dumps(body).encode("utf-8")
 
     def test_confirm_payment_one_step(self):
-        result = self.service.dispatch(
-            "confirm_payment",
-            params={
-                "target": "demo_partner",
-                "payment_mode_id": self.payment_mode.id,
-                "stripe_payment_method_id": "pm_card_visa",
-            },
+        result = self.service.confirm_payment(
+            target="demo_partner",
+            payment_mode_id=self.payment_mode.id,
+            stripe_payment_method_id="pm_card_visa",
         )
         self.assertEqual(result, {"success": True})
         self.assertDictEqual(
@@ -57,13 +54,10 @@ class TestInvaderPaymentStripe(VCRMixin, TestCommonPayment):
         )
 
     def test_confirm_payment_two_step(self):
-        result = self.service.dispatch(
-            "confirm_payment",
-            params={
-                "target": "demo_partner",
-                "payment_mode_id": self.payment_mode.id,
-                "stripe_payment_method_id": "pm_card_threeDSecure2Required",
-            },
+        result = self.service.confirm_payment(
+            target="demo_partner",
+            payment_mode_id=self.payment_mode.id,
+            stripe_payment_method_id="pm_card_threeDSecure2Required",
         )
         self.assertIn("requires_action", result)
         self.assertTrue(result["requires_action"])
@@ -78,13 +72,10 @@ class TestInvaderPaymentStripe(VCRMixin, TestCommonPayment):
         # on server side so the simpliest solution is to
         # hack the next response
         self._alter_next_response({"status": "succeeded"})
-        result = self.service.dispatch(
-            "confirm_payment",
-            params={
-                "target": "demo_partner",
-                "payment_mode_id": self.payment_mode.id,
-                "stripe_payment_intent_id": stripe_payment_intent_id,
-            },
+        result = self.service.confirm_payment(
+            target="demo_partner",
+            payment_mode_id=self.payment_mode.id,
+            stripe_payment_intent_id=stripe_payment_intent_id,
         )
         self.assertEqual(result, {"success": True})
 
@@ -93,13 +84,10 @@ class TestInvaderPaymentStripe(VCRMixin, TestCommonPayment):
             "invader_payment_manual.payment_mode_check"
         )
         with self.assertRaises(UserError) as m:
-            self.service.dispatch(
-                "confirm_payment",
-                params={
-                    "target": "demo_partner",
-                    "payment_mode_id": self.payment_mode_check.id,
-                    "stripe_payment_method_id": "pm_card_visa",
-                },
+            self.service.confirm_payment(
+                target="demo_partner",
+                payment_mode_id=self.payment_mode_check.id,
+                stripe_payment_method_id="pm_card_visa",
             )
         self.assertEqual(
             m.exception.name,


### PR DESCRIPTION
…omponent

invader_payment_* addons provides abstract services. Therefore, the service's methods are not publicly exposed as a REST api since no controller is registered to serve these methods. To test these methodes you must call them directly. Indeed, the generic dispatch method can't be used to access these methods in the current context since it checks if a route is associated to ensure that the method is public. (Change required by the new implemantation of base_rest)