### PR TITLE
[FIX] do not set last_sale when not in customer session

### DIFF
--- a/shopinvader_payment/components/payment_transaction_event_listerner.py
+++ b/shopinvader_payment/components/payment_transaction_event_listerner.py
@@ -1,5 +1,7 @@
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.http import request
+
 from odoo.addons.base_rest.controllers.main import _PseudoCollection
 from odoo.addons.component.core import Component
 from odoo.addons.shopinvader import shopinvader_response
@@ -15,8 +17,13 @@ class SaleOrderPaymentTransactionEventListener(Component):
         if not shopinvader_backend:
             return
         sale_order.action_confirm_cart()
+        try:
+            sess_cart_id = request.httprequest.environ.get("HTTP_SESS_CART_ID")
+        except RuntimeError:
+            # not in an http request (testing?)
+            sess_cart_id = None
         response = shopinvader_response.get(raise_if_not_found=False)
-        if response:
+        if response and sess_cart_id:
             response.set_session("cart_id", 0)
             response.set_store_cache("cart", {})
             # TODO we should not have to return the last_sale


### PR DESCRIPTION
The SaleOrderPaymentTransactionEventListener is sometimes called
when the transaction is confirmed by a webhook coming from the payment
acquirer. We don't want to leak the store_cache to the payment acquirer,
so we only set it if we are in a customer session.

To detect that we are in a customer session we check the sess-cart-id
HTTP header.

This is part of the collection of ugly patches in this area.
