### PR TITLE
[13.0] s_payment: load partner work ctx properly

### DIFF
--- a/shopinvader_payment/components/payment_transaction_event_listerner.py
+++ b/shopinvader_payment/components/payment_transaction_event_listerner.py
@@ -1,11 +1,15 @@
 # Copyright 2019 ACSONE SA/NV
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
 from odoo.http import request
 
-from odoo.addons.base_rest.controllers.main import _PseudoCollection
 from odoo.addons.component.core import Component
 from odoo.addons.shopinvader import shopinvader_response
 from odoo.addons.shopinvader.utils import work_on_service_with_partner
+
+_logger = logging.getLogger(__name__)
 
 
 class SaleOrderPaymentTransactionEventListener(Component):
@@ -38,6 +42,15 @@ class SaleOrderPaymentTransactionEventListener(Component):
             invader_partner = sale_order.partner_id._get_invader_partner(
                 shopinvader_backend
             )
+            if not invader_partner:
+                _logger.error(
+                    f"Could not find invader_partner for sale order {sale_order.id}"
+                )
+                return
+            if not invader_partner.active:
+                _logger.warning(
+                    f"Inactive invader_partner found for sale order {sale_order.id}"
+                )
             with work_on_service_with_partner(
                 self.env, invader_partner
             ) as work:


### PR DESCRIPTION
Make sure that when the cart service is initialized
we have the whole partner work context in good shape.

Depends on https://github.com/shopinvader/odoo-shopinvader/pull/957

Replaces #41 