### PR TITLE
[FIX] 14.0 SO transaction amount: remove paid amount

### DIFF
--- a/shopinvader_payment/components/payment_transaction_event_listerner.py
+++ b/shopinvader_payment/components/payment_transaction_event_listerner.py
@@ -58,4 +58,7 @@ class SaleOrderPaymentTransactionEventListener(Component):
             # end of awful code ....
 
     def on_payment_transaction_done(self, sale_order, transaction):
-        self._confirm_and_invalidate_session(sale_order)
+        # TODO: remove _confirm_and_invalidate_session if everything works
+        #self._confirm_and_invalidate_session(sale_order)
+        # instantly post_process_order
+        transaction._post_process_after_done()

--- a/shopinvader_payment/models/payment_transaction.py
+++ b/shopinvader_payment/models/payment_transaction.py
@@ -13,3 +13,17 @@ class PaymentTransaction(models.Model):
         if self.sale_order_ids:
             return self.sale_order_ids
         return super(PaymentTransaction, self)._get_invader_payables()
+
+    def _check_amount_and_confirm_order(self):
+        self.ensure_one()
+        for order in self.sale_order_ids.filtered(
+            lambda so: so.state in ("draft", "sent")
+        ):
+            transactions = order.transaction_ids
+            done_transactions = transactions.filtered(lambda t: t.state == "done")
+            paid_amount = sum(done_transactions.mapped("amount"))
+            if order.currency_id.compare_amounts(order.amount_total, paid_amount) == 0:
+                order.with_context(send_email=True).action_confirm()
+                unfinished_transactions = transactions - done_transactions
+                unfinished_transactions._set_transaction_cancel()
+        return super()._check_amount_and_confirm_order()

--- a/shopinvader_payment/models/sale_order.py
+++ b/shopinvader_payment/models/sale_order.py
@@ -19,8 +19,9 @@ class SaleOrder(models.Model):
                 % (acquirer_id.name, self.shopinvader_backend_id.name)
             )
         self.ensure_one()
+        paid_amount = sum(self.transaction_ids.filtered(lambda l: l.state in ["authorized", "done"]).mapped("amount"))
         vals = {
-            "amount": self.amount_total,
+            "amount": self.amount_total - paid_amount,
             "currency_id": self.currency_id.id,
             "partner_id": self.partner_id.id,
             "acquirer_id": acquirer_id.id,

--- a/shopinvader_payment/services/abstract_payable_sale.py
+++ b/shopinvader_payment/services/abstract_payable_sale.py
@@ -3,6 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 
+from odoo.tools.float_utils import float_round
+
 from odoo.addons.component.core import AbstractComponent
 
 
@@ -12,6 +14,9 @@ class AbstractPayableSaleService(AbstractComponent):
 
     def _get_available_payment_methods(self, sale):
         return sale.shopinvader_backend_id.payment_method_ids
+
+    def _get_existing_transactions(self, sale):
+        return sale.transaction_ids
 
     def _get_shopinvader_payment_data(self, sale):
         """
@@ -25,14 +30,39 @@ class AbstractPayableSaleService(AbstractComponent):
         :return:
         """
         payment_methods = self._get_available_payment_methods(sale)
+        currency = sale.currency_id
+        transactions = self._get_existing_transactions(sale)
+        amount_paid = float_round(sum(transactions.filtered(lambda l: l.state in ["authorized", "done"]).mapped("amount")), precision_rounding=currency.rounding)
         values = {
             "available_methods": {
                 "count": len(payment_methods),
                 "items": self._get_payment_method_data(payment_methods),
             },
-            "amount": sale.amount_total,
+            "existing_transactions": {
+                "count": len(transactions),
+                "items": self._get_transaction_data(transactions),
+            },
+            "amount": sale.amount_total - amount_paid,
+            "amount_paid": amount_paid,
+            "amount_total": sale.amount_total,
         }
         return values
+
+    def _get_transaction_data(self, transactions):
+        res = []
+        for transaction in transactions:
+            res.append(
+                {
+                    "id": transaction.id,
+                    "name": transaction.reference,
+                    "payment_method_id": transaction.acquirer_id.id,
+                    "payment_method_name": transaction.acquirer_id.name,
+                    "date": transaction.date,
+                    "amount": transaction.amount,
+                    "state": transaction.state,
+                }
+            )
+        return res
 
     def _get_payment_method_data(self, methods):
         res = []


### PR DESCRIPTION
While creating the transaction, shopinvader_payment uses the sale_order amount_total.

This works well when using 1 transaction. But when using several transactions, all of them are created with amount_total as amount.

It should be decremented, this is what this PR does