### PR TITLE
[FIX] shopinvader_payment_condition: Don't take into account existing…

### DIFF
--- a/shopinvader_payment_condition/tests/test_payment.py
+++ b/shopinvader_payment_condition/tests/test_payment.py
@@ -10,6 +10,10 @@ class ShopinvaderPaymentCase(CommonConnectedCartCase):
         super().setUp()
         # TODO: This should be in setUpClass, but it needs to be changed
         #       in CommonConnectedCartCase first.
+
+        # Deactivate existing payment methods first
+        self.env["shopinvader.payment"].search([]).unlink()
+
         self.acquirer_a, self.acquirer_b = self.env["payment.acquirer"].create(
             [
                 {"name": "Fake Acquirer A", "provider": "manual"},


### PR DESCRIPTION
… methods in tests

@ivantodorovich You can see the related error there : https://github.com/shopinvader/odoo-shopinvader-payment/actions/runs/3959332658/jobs/6782015100#step:8:172