### PR TITLE
[14.0][FIX] invader_payment_adyen: Missing PSP

### DIFF
--- a/invader_payment_adyen/models/payment_transaction.py
+++ b/invader_payment_adyen/models/payment_transaction.py
@@ -203,7 +203,8 @@ class PaymentTransaction(models.Model):
         payment_data = response.message.get("paymentData")
         if payment_data:
             vals.update({"adyen_payment_data": payment_data})
-        psp_reference = response.message.get("pspReference")
+        # In some strange case, we doesn't have this pspReference
+        psp_reference = response.message.get("pspReference") or response.psp
         if psp_reference:
             vals.update({"acquirer_reference": psp_reference})
         result_code = response.message.get("resultCode")


### PR DESCRIPTION
In some case, the payment checkout doesn't send enough information (`paymentData` empty and no `pspReference`). As the `psp` is required (link between Odoo and Adyen), we have to fill it during this step. This value is also into `response.psp`.