### PR TITLE
[16.0] shopinvader_api_payment: fix dependency on sips

### DIFF
--- a/shopinvader_api_payment/__manifest__.py
+++ b/shopinvader_api_payment/__manifest__.py
@@ -12,7 +12,6 @@
     "depends": [
         "fastapi",
         "payment",
-        "payment_sips",
         "pydantic",
         "extendable",
         "extendable_fastapi",


### PR DESCRIPTION
This dep is not needed in the base module.

@lmignon ping :)